### PR TITLE
Fix for deprecated use of null as parameter where int is expected

### DIFF
--- a/src/NlpTools/Tokenizers/WhitespaceTokenizer.php
+++ b/src/NlpTools/Tokenizers/WhitespaceTokenizer.php
@@ -14,6 +14,6 @@ class WhitespaceTokenizer implements TokenizerInterface
     {
         $arr = array();
 
-        return preg_split(self::PATTERN,$str,null,PREG_SPLIT_NO_EMPTY);
+        return preg_split(self::PATTERN,$str,0,PREG_SPLIT_NO_EMPTY);
     }
 }


### PR DESCRIPTION
  DEPRECATED  preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in vendor/nlp-tools/nlp-tools/src/NlpTools/Tokenizers/WhitespaceTokenizer.php on line 17.