### PR TITLE
Feat : Add French Normalizer

### DIFF
--- a/src/NlpTools/Utils/Normalizers/French.php
+++ b/src/NlpTools/Utils/Normalizers/French.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace NlpTools\Utils\Normalizers;
+
+class French extends Normalizer
+{
+    protected static $dirty = array(
+        'à', 'â', 'ä', 'é', 'è', 'ê', 'ë', 'î', 'ï',
+        'ô', 'ö', 'ù', 'û', 'ü', 'ÿ', 'œ', 'æ', 'ç'
+    );
+
+    protected static $clean = array(
+        'a', 'a', 'a', 'e', 'e', 'e', 'e', 'i', 'i',
+        'o', 'o', 'u', 'u', 'u', 'y', 'oe', 'ae', 'c'
+    );
+
+    public function normalize($w)
+    {
+        return str_replace(self::$dirty, self::$clean, \mb_strtolower($w, "utf-8"));
+    }
+}


### PR DESCRIPTION
To normalize French text, we use mb_strtolower to transform it to lower case and then replace every accented character with its non-accented counter part, and the final 'ç' with 'c'.